### PR TITLE
Fix bug in examples: ckpt_name should accept list of str only

### DIFF
--- a/examples/inference/custom_encoder/beir_scifact/run.py
+++ b/examples/inference/custom_encoder/beir_scifact/run.py
@@ -7,7 +7,7 @@ register('splade_stopwords', splade_stopwords)  # Register your custom encoders 
 if __name__ == '__main__':
     aio.run(
         encoder_name='splade_stopwords',
-        ckpt_name='distilsplade_max',
+        ckpt_name=['distilsplade_max',],
         data_name='beir/scifact',
         gpus=[5, 6],
         output_dir='beir_scifact-distilsplade_max-stopwords',

--- a/examples/inference/distilsplade_max/beir_scifact/run.py
+++ b/examples/inference/distilsplade_max/beir_scifact/run.py
@@ -28,7 +28,7 @@ if __name__ == '__main__':  # aio.run can only be called within __main__
 
     aio.run(
         encoder_name='splade',
-        ckpt_name='distilsplade_max',
+        ckpt_name=['distilsplade_max',],
         data_name='beir/scifact',
         gpus=[11, 12],
         output_dir='beir_scifact-distilsplade_max',

--- a/examples/inference/unicoil-d2q/beir_scifact/run.py
+++ b/examples/inference/unicoil-d2q/beir_scifact/run.py
@@ -15,7 +15,7 @@ if __name__ == '__main__':  # aio.run can only be called within __main__
 
     aio.run(
         encoder_name='unicoil',
-        ckpt_name=args.model_name_or_path,
+        ckpt_name=[args.model_name_or_path,],
         data_name='beir/{}'.format(args.dataset),
         train_data_dir=args.train_data_dir,
         eval_data_dir=args.eval_data_dir,

--- a/examples/inference/unicoil-noexp/beir_scifact/run.py
+++ b/examples/inference/unicoil-noexp/beir_scifact/run.py
@@ -4,7 +4,7 @@ from sparse_retrieval.inference import aio
 if __name__ == '__main__':  # aio.run can only be called within __main__
     aio.run(
         encoder_name='unicoil',
-        ckpt_name='castorini/unicoil-noexp-msmarco-passage',
+        ckpt_name=['castorini/unicoil-noexp-msmarco-passage',],
         data_name='beir/scifact',
         gpus=[0, 1],
         output_dir='beir_scifact-unicoil_noexp',


### PR DESCRIPTION
`aio.run` in the examples should accept `ckpt_name` as a list of strings. However, the current examples assign a single string to this argument. This PR fixes this.